### PR TITLE
feat: export aliases `t` and `n` for `translate` and `translatePlural`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ You can use helpers in this package in order generate code that also works when 
 In order to not break the l10n string extraction scripts, make sure to alias the imported function to match the legacy syntax:
 
 ```js
-import {translate as t, translatePlural as n} from '@nextcloud/l10n'
+import { t, n } from '@nextcloud/l10n'
+// Or
+import { translate as t, translatePlural as n } from '@nextcloud/l10n'
 
 t('myapp', 'Hello!')
 n('myapp', '%n cloud', '%n clouds', 100)

--- a/lib/translation.ts
+++ b/lib/translation.ts
@@ -399,3 +399,10 @@ export function getPlural(number: number) {
 		return 0
 	}
 }
+
+// Export short-hand
+
+export {
+	translate as t,
+	translatePlural as n,
+}

--- a/tests/translation.test.ts
+++ b/tests/translation.test.ts
@@ -5,6 +5,8 @@ import {
 	translate,
 	translatePlural,
 	unregister,
+	t,
+	n,
 } from '../lib/translation'
 
 declare const window: NextcloudWindowWithRegistry
@@ -138,6 +140,14 @@ describe('translate', () => {
 
 		expect(translatePlural('core', ...text, 1)).toBe('Lade 1 Datei von {url} herunter')
 		expect(translatePlural('core', ...text, 2)).toBe('Lade 2 Dateien von {url} herunter')
+	})
+
+	it('has "t" alias for "translate"', () => {
+		expect(t).toBe(translate)
+	})
+
+	it('has "n" alias for "translatePlural"', () => {
+		expect(n).toBe(translatePlural)
 	})
 })
 


### PR DESCRIPTION
We do this all the time:
```js
import { translate as t, translatePlural as n } from '@nextcloud/l10n'
```

This PR allows importing aliases as well in a simple way:
```js
import { t, n } from '@nextcloud/l10n'
```

