### PR TITLE
chore: Prepare 3.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 3.1.0 - 2024-05-07
+
+### Added
+
+*   Allow setting `escape` option per parameter replacing.\
+	For more security this should be used instead of disabling paramter escaping,
+	see [pull request #756](https://github.com/nextcloud-libraries/nextcloud-l10n/pull/756)
+	```js
+	// Example
+	t(
+		'my-app',
+		'{a}{userInput}{a_end}',
+		{
+			a: {
+				value: '<a>',
+				escape: false,
+			},
+			userInput: somePossiblyInsecureValue, // This will be escaped
+			a_end: {
+				value: '</a>',
+				escape: false,
+			}
+		},
+	)
+	```
+
 ## 3.0.1 - 2024-05-04
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/l10n",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/l10n",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/router": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/l10n",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Nextcloud L10n helpers for apps and libraries",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## 3.1.0 - 2024-05-07

### Added

*   Allow setting `escape` option per parameter replacing.\
	For more security this should be used instead of disabling paramter escaping,
	see [pull request #756](https://github.com/nextcloud-libraries/nextcloud-l10n/pull/756)
	```js
	// Example
	t(
		'my-app',
		'{a}{userInput}{a_end}',
		{
			a: {
				value: '<a>',
				escape: false,
			},
			userInput: somePossiblyInsecureValue, // This will be escaped
			a_end: {
				value: '</a>',
				escape: false,
			}
		},
	)
	```