### PR TITLE
feat(date): fallback to Intl

### DIFF
--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,5 +1,7 @@
 /// <reference types="@nextcloud/typings" />
 
+import { getCanonicalLocale } from './locale'
+
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
@@ -13,12 +15,30 @@ declare let window: Nextcloud.v27.WindowWithGlobals
  * @return {number}
  */
 export function getFirstDay(): number {
-	if (typeof window.firstDay === 'undefined') {
-		console.warn('No firstDay found')
-		return 1
+	// Server rendered
+	if (typeof window.firstDay !== 'undefined') {
+		return window.firstDay
 	}
 
-	return window.firstDay
+	// Try to fallback to Intl
+	// getWeekInfo is a Stage 3 proposal and not available in Firefox
+	// Node.js and Samsung Internet only has accessor property weekInfo instead
+	type WeekInfoDay = 1 | 2 | 3 | 4 | 5 | 6 | 7
+	type WeekInfo = {
+		firstDay: WeekInfoDay,
+		weekend: WeekInfoDay,
+		minimalDays: WeekInfoDay,
+	 }
+	const intl = new Intl.Locale(getCanonicalLocale())
+	// @ts-expect-error These properties are not part of the standard
+	const weekInfo: WeekInfo = intl.getWeekInfo?.() ?? intl.weekInfo
+	if (weekInfo) {
+		// Convert 1..7 to 0..6 format
+		return weekInfo.firstDay % 7
+	}
+
+	// Fallback to Monday
+	return 1
 }
 
 /**
@@ -27,20 +47,22 @@ export function getFirstDay(): number {
  * @return {string[]}
  */
 export function getDayNames(): string[] {
-	if (typeof window.dayNames === 'undefined') {
-		console.warn('No dayNames found')
-		return [
-			'Sunday',
-			'Monday',
-			'Tuesday',
-			'Wednesday',
-			'Thursday',
-			'Friday',
-			'Saturday',
-		]
+	// Server rendered
+	if (typeof window.dayNames !== 'undefined') {
+		return window.dayNames
 	}
 
-	return window.dayNames
+	// Fallback to Intl
+	const locale = getCanonicalLocale()
+	return [
+		new Date('1970-01-04T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'long' }),
+		new Date('1970-01-05T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'long' }),
+		new Date('1970-01-06T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'long' }),
+		new Date('1970-01-07T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'long' }),
+		new Date('1970-01-08T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'long' }),
+		new Date('1970-01-09T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'long' }),
+		new Date('1970-01-10T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'long' }),
+	]
 }
 
 /**
@@ -49,12 +71,22 @@ export function getDayNames(): string[] {
  * @return {string[]}
  */
 export function getDayNamesShort(): string[] {
-	if (typeof window.dayNamesShort === 'undefined') {
-		console.warn('No dayNamesShort found')
-		return ['Sun.', 'Mon.', 'Tue.', 'Wed.', 'Thu.', 'Fri.', 'Sat.']
+	if (typeof window.dayNamesShort !== 'undefined') {
+		return window.dayNamesShort
 	}
 
-	return window.dayNamesShort
+	// Fallback to Intl
+	// Note: narrow is shorter than server's "min", but it's the closest we can get
+	const locale = getCanonicalLocale()
+	return [
+		new Date('1970-01-04T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'short' }),
+		new Date('1970-01-05T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'short' }),
+		new Date('1970-01-06T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'short' }),
+		new Date('1970-01-07T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'short' }),
+		new Date('1970-01-08T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'short' }),
+		new Date('1970-01-09T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'short' }),
+		new Date('1970-01-10T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'short' }),
+	]
 }
 
 /**
@@ -63,12 +95,22 @@ export function getDayNamesShort(): string[] {
  * @return {string[]}
  */
 export function getDayNamesMin(): string[] {
-	if (typeof window.dayNamesMin === 'undefined') {
-		console.warn('No dayNamesMin found')
-		return ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
+	// Server rendered
+	if (typeof window.dayNamesMin !== 'undefined') {
+		return window.dayNamesMin
 	}
 
-	return window.dayNamesMin
+	// Fallback to Intl
+	const locale = getCanonicalLocale()
+	return [
+		new Date('1970-01-04T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'narrow' }),
+		new Date('1970-01-05T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'narrow' }),
+		new Date('1970-01-06T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'narrow' }),
+		new Date('1970-01-07T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'narrow' }),
+		new Date('1970-01-08T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'narrow' }),
+		new Date('1970-01-09T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'narrow' }),
+		new Date('1970-01-10T00:00:00.000Z').toLocaleDateString(locale, { weekday: 'narrow' }),
+	]
 }
 
 /**
@@ -77,25 +119,27 @@ export function getDayNamesMin(): string[] {
  * @return {string[]}
  */
 export function getMonthNames(): string[] {
-	if (typeof window.monthNames === 'undefined') {
-		console.warn('No monthNames found')
-		return [
-			'January',
-			'February',
-			'March',
-			'April',
-			'May',
-			'June',
-			'July',
-			'August',
-			'September',
-			'October',
-			'November',
-			'December',
-		]
+	// Server rendered
+	if (typeof window.monthNames !== 'undefined') {
+		return window.monthNames
 	}
 
-	return window.monthNames
+	// Fallback to Intl
+	const locale = getCanonicalLocale()
+	return [
+		new Date('1970-01-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'long' }),
+		new Date('1970-02-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'long' }),
+		new Date('1970-03-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'long' }),
+		new Date('1970-04-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'long' }),
+		new Date('1970-05-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'long' }),
+		new Date('1970-06-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'long' }),
+		new Date('1970-07-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'long' }),
+		new Date('1970-08-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'long' }),
+		new Date('1970-09-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'long' }),
+		new Date('1970-10-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'long' }),
+		new Date('1970-11-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'long' }),
+		new Date('1970-12-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'long' }),
+	]
 }
 
 /**
@@ -104,23 +148,25 @@ export function getMonthNames(): string[] {
  * @return {string[]}
  */
 export function getMonthNamesShort(): string[] {
-	if (typeof window.monthNamesShort === 'undefined') {
-		console.warn('No monthNamesShort found')
-		return [
-			'Jan.',
-			'Feb.',
-			'Mar.',
-			'Apr.',
-			'May.',
-			'Jun.',
-			'Jul.',
-			'Aug.',
-			'Sep.',
-			'Oct.',
-			'Nov.',
-			'Dec.',
-		]
+	// Server rendered
+	if (typeof window.monthNamesShort !== 'undefined') {
+		return window.monthNamesShort
 	}
 
-	return window.monthNamesShort
+	// Fallback to Intl
+	const locale = getCanonicalLocale()
+	return [
+		new Date('1970-01-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'short' }),
+		new Date('1970-02-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'short' }),
+		new Date('1970-03-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'short' }),
+		new Date('1970-04-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'short' }),
+		new Date('1970-05-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'short' }),
+		new Date('1970-06-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'short' }),
+		new Date('1970-07-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'short' }),
+		new Date('1970-08-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'short' }),
+		new Date('1970-09-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'short' }),
+		new Date('1970-10-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'short' }),
+		new Date('1970-11-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'short' }),
+		new Date('1970-12-01T00:00:00.000Z').toLocaleDateString(locale, { month: 'short' }),
+	]
 }

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -4,114 +4,190 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mocked } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDayNames, getDayNamesMin, getDayNamesShort, getFirstDay, getMonthNames, getMonthNamesShort } from '../lib/date'
+import * as localeModule from '../lib/locale'
+
+vi.mock('../lib/locale')
+const { getCanonicalLocale } = localeModule as Mocked<typeof localeModule>
 
 declare let window: Nextcloud.v24.WindowWithGlobals
 
 describe('date', () => {
-	const orginalWarn = console.warn
-
-	afterAll(() => {
-		console.warn = orginalWarn
-	})
-	beforeEach(() => {
-		console.warn = vi.fn()
-	})
-
 	describe('getFirstDay', () => {
-		// @ts-ignore
-		afterAll(() => { delete window.firstDay })
+		const weekInfoMocks = {
+			'en-US': { firstDay: 7, weekend: [6, 7], minimalDays: 1 },
+			'de-DE': { firstDay: 1, weekend: [6, 7], minimalDays: 4 },
+		} as const
 
-		it('works without `OC`', () => {
-			expect(getFirstDay()).toBe(1)
-			// Warning as fallback is being used
-			expect(console.warn).toBeCalled()
+		const mockGetWeekInfo = function(this: Intl.Locale) {
+			const weekInfo = weekInfoMocks[this.baseName as keyof typeof weekInfoMocks]
+			if (weekInfo) {
+				return weekInfo
+			}
+			throw new Error(`Locale ${this.baseName} is not implemented in tests`)
+		}
+
+		const originalGetWeekInfo = Intl.Locale.prototype.getWeekInfo
+		const originalWeekInfoDescriptor = Object.getOwnPropertyDescriptor(Intl.Locale.prototype, 'weekInfo')!
+
+		beforeEach(() => {
+			// @ts-ignore
+			delete window.firstDay
 		})
 
-		it('works with `OC`', () => {
+		afterEach(() => {
+			vi.clearAllMocks()
+			Intl.Locale.prototype.getWeekInfo = originalGetWeekInfo
+			Object.defineProperty(Intl.Locale.prototype, 'weekInfo', originalWeekInfoDescriptor)
+		})
+
+		it('returns `window.firstDate` when defined', () => {
 			window.firstDay = 3
 			expect(getFirstDay()).toBe(3)
+		})
+
+		it('returns 1 (Monday) in "de-DE" locale when `window.firstDate` is not defined but `Intl.weekInfo` is defined (Node.js, Samsung Internet)', () => {
+			getCanonicalLocale.mockReturnValue('de-DE')
+			expect(getFirstDay()).toBe(1)
+		})
+
+		it('returns 0 (Sunday) in "en-US" locale when `window.firstDate` is not defined but `Intl.weekInfo` is defined (Node.js, Samsung Internet)', () => {
+			getCanonicalLocale.mockReturnValue('en-US')
+			expect(getFirstDay()).toBe(0)
+		})
+
+		it('returns 1 (Monday) in "de-DE" locale when `window.firstDate` is not defined but `Intl.getWeekInfo` is defined (Chromium, Safari)', () => {
+			getCanonicalLocale.mockReturnValue('de-DE')
+			// getWeekInfo is available, weekInfo is not available (Chromium, Safari)
+			Intl.Locale.prototype.getWeekInfo = mockGetWeekInfo
+			delete Intl.Locale.prototype.weekInfo
+			expect(getFirstDay()).toBe(1)
+		})
+
+		it('returns 0 (Sunday) in "en-US" locale when `window.firstDate` is not defined but `Intl.getWeekInfo` is defined (Chromium, Safari)', () => {
+			getCanonicalLocale.mockReturnValue('en-US')
+			// getWeekInfo is available, weekInfo is not available (Chromium, Safari)
+			Intl.Locale.prototype.getWeekInfo = mockGetWeekInfo
+			delete Intl.Locale.prototype.weekInfo
+			expect(getFirstDay()).toBe(0)
+		})
+
+		it('returns 1 (Monday) when neither `window.firstDate` nor `Intl.Locale.getWeekInfo`/`weekInfo` is defined (Firefox)', () => {
+			delete Intl.Locale.prototype.getWeekInfo
+			delete Intl.Locale.prototype.weekInfo
+			expect(getFirstDay()).toBe(1)
 		})
 	})
 
 	describe('getDayNames', () => {
-		// @ts-ignore
-		afterAll(() => { delete window.dayNames })
-
-		it('works without `OC`', () => {
-			expect(getDayNames().length).toBe(7)
-			// Warning as fallback is being used
-			expect(console.warn).toBeCalled()
+		afterEach(() => {
+			// @ts-ignore
+			delete window.dayNames
 		})
 
-		it('works with `OC`', () => {
-			window.dayNames = 'a'.repeat(7).split('')
-			expect(getDayNames()).toBe(window.dayNames)
+		it('returns `window.dayNames` when defined', () => {
+			window.dayNames = ['Day 0', 'Day 1', 'Day 2', 'Day 3', 'Day 4', 'Day 5', 'Day 6']
+			expect(getDayNames()).toEqual(window.dayNames)
+		})
+
+		it('returns English day names in "en-US" locale when `window.dayNames` is not defined', () => {
+			getCanonicalLocale.mockReturnValue('en-US')
+			expect(getDayNames()).toEqual(['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'])
+		})
+
+		it('returns German day names in "de-DE" locale when `window.dayNames` is not defined', () => {
+			getCanonicalLocale.mockReturnValue('de-DE')
+			expect(getDayNames()).toEqual(['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'])
 		})
 	})
 
 	describe('getDayNamesShort', () => {
-		// @ts-ignore
-		afterAll(() => { delete window.dayNamesShort })
-
-		it('works without `OC`', () => {
-			expect(getDayNamesShort().length).toBe(7)
-			// Warning as fallback is being used
-			expect(console.warn).toBeCalled()
+		afterEach(() => {
+			// @ts-ignore
+			delete window.dayNamesShort
 		})
 
-		it('works with `OC`', () => {
-			window.dayNamesShort = 'b'.repeat(7).split('')
-			expect(getDayNamesShort()).toBe(window.dayNamesShort)
+		it('returns `window.dayNamesShort` when defined', () => {
+			window.dayNamesShort = ['D. 0', 'D. 1', 'D. 2', 'D. 3', 'D. 4', 'D. 5', 'D. 6']
+			expect(getDayNamesShort()).toEqual(window.dayNamesShort)
+		})
+
+		it('returns English short day names from `Intl` in "en-US" locale when `window.dayNamesShort` is not defined', () => {
+			getCanonicalLocale.mockReturnValue('en-US')
+			expect(getDayNamesShort()).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'])
+		})
+
+		it('returns German short day names from `Intl` in "de-DE" locale when `window.dayNamesShort` is not defined', () => {
+			getCanonicalLocale.mockReturnValue('de-DE')
+			expect(getDayNamesShort()).toEqual(['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'])
 		})
 	})
 
 	describe('getDayNamesMin', () => {
-		// @ts-ignore
-		afterAll(() => { delete window.dayNamesMin })
-
-		it('works without `OC`', () => {
-			expect(getDayNamesMin().length).toBe(7)
-			// Warning as fallback is being used
-			expect(console.warn).toBeCalled()
+		afterEach(() => {
+			// @ts-ignore
+			delete window.dayNamesMin
 		})
 
-		it('works with `OC`', () => {
-			window.dayNamesMin = 'c'.repeat(7).split('')
-			expect(getDayNamesMin()).toBe(window.dayNamesMin)
+		it('returns `window.dayNamesMin` when defined', () => {
+			window.dayNamesMin = ['D0', 'D1', 'D2', 'D3', 'D4', 'D5', 'D6']
+			expect(getDayNamesMin()).toEqual(window.dayNamesMin)
+		})
+
+		it('returns English narrow day names from `Intl` in "en-US" locale when `window.dayNamesMin` is not defined', () => {
+			getCanonicalLocale.mockReturnValue('en-US')
+			expect(getDayNamesMin()).toEqual(['S', 'M', 'T', 'W', 'T', 'F', 'S'])
+		})
+
+		it('returns German narrow day names from `Intl` in "de-DE" locale when `window.dayNamesMin` is not defined', () => {
+			getCanonicalLocale.mockReturnValue('de-DE')
+			expect(getDayNamesMin()).toEqual(['S', 'M', 'D', 'M', 'D', 'F', 'S'])
 		})
 	})
 
 	describe('getMonthNames', () => {
-		// @ts-ignore
-		afterAll(() => { delete window.monthNames })
-
-		it('works without `OC`', () => {
-			expect(getMonthNames().length).toBe(12)
-			// Warning as fallback is being used
-			expect(console.warn).toBeCalled()
+		afterEach(() => {
+			// @ts-ignore
+			delete window.monthNames
 		})
 
-		it('works with `OC`', () => {
-			window.monthNames = 'd'.repeat(12).split('')
-			expect(getMonthNames()).toBe(window.monthNames)
+		it('returns `window.monthNames` when defined', () => {
+			window.monthNames = ['Month 0', 'Month 1', 'Month 2', 'Month 3', 'Month 4', 'Month 5', 'Month 6', 'Month 7', 'Month 8', 'Month 9', 'Month 10', 'Month 11']
+			expect(getMonthNames()).toEqual(window.monthNames)
+		})
+
+		it('returns English month names from `Intl` in "en-US" locale when `window.monthNames` is not defined', () => {
+			getCanonicalLocale.mockReturnValue('en-US')
+			expect(getMonthNames()).toEqual(['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'])
+		})
+
+		it('returns German month names from `Intl` in "de-DE" locale when `window.monthNames` is not defined', () => {
+			getCanonicalLocale.mockReturnValue('de-DE')
+			expect(getMonthNames()).toEqual(['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'])
 		})
 	})
 
 	describe('getMonthNamesShort', () => {
-		// @ts-ignore
-		afterAll(() => { delete window.monthNamesShort })
-
-		it('works without `OC`', () => {
-			expect(getMonthNamesShort().length).toBe(12)
-			// Warning as fallback is being used
-			expect(console.warn).toBeCalled()
+		afterEach(() => {
+			// @ts-ignore
+			delete window.monthNamesShort
 		})
 
-		it('works with `OC`', () => {
-			window.monthNamesShort = 'e'.repeat(12).split('')
-			expect(getMonthNamesShort()).toBe(window.monthNamesShort)
+		it('returns `window.monthNamesShort` when defined', () => {
+			window.monthNamesShort = ['M. 0', 'M. 1', 'M. 2', 'M. 3', 'M. 4', 'M. 5', 'M. 6', 'M. 7', 'M. 8', 'M. 9', 'M. 10', 'M. 11']
+			expect(getMonthNamesShort()).toEqual(window.monthNamesShort)
+		})
+
+		it('returns English short month names from `Intl` in "en-US" locale when `window.monthNamesShort` is not defined', () => {
+			getCanonicalLocale.mockReturnValue('en-US')
+			expect(getMonthNamesShort()).toEqual(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'])
+		})
+
+		it('returns German short month names from `Intl` in "de-DE" locale when `window.monthNamesShort` is not defined', () => {
+			getCanonicalLocale.mockReturnValue('de-DE')
+			expect(getMonthNamesShort()).toEqual(['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'])
 		})
 	})
 })


### PR DESCRIPTION
## Resolves

Currently all the function from `date` module returns required server rendered global variables like
```js
window.dayNames
```

This PR allows to use these functions outside the server render context (apps) using `Intl`, for example:
- Web-Browser workers
- Documentations
- Talk Desktop

Drawbacks:
- `firstDay` is not available on Firefox
- Intl weekday in narrow format is different from `dayNamesMin`

## Alternatives

1. Add an init method to set these variables with the same Intl values
2. Do nothing, this is not a real problem