### PR TITLE
refactor(gettext): Drop `node-gettext` dependency and use our translation logic

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,16 @@
 {
 	"extends": [
-		"@nextcloud"
+		"@nextcloud/eslint-config/typescript"
 	],
 	"ignorePatterns": ["dist"],
 	"overrides": [
+		{
+			"files": ["**.ts"],
+			"rules": {
+				"no-useless-constructor": "off",
+				"@typescript-eslint/no-useless-constructor": "error"
+			}
+		},
 		{
 			"files": ["tests/*.js"],
 			"rules": {

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -46,7 +46,7 @@ export interface NextcloudWindowWithRegistry extends Nextcloud.v27.WindowWithGlo
 
 declare const window: NextcloudWindowWithRegistry
 
-interface AppTranslations {
+export interface AppTranslations {
 	translations: Translations
 	pluralFunction: PluralFunction
 }

--- a/lib/translation.ts
+++ b/lib/translation.ts
@@ -2,15 +2,15 @@
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-import type { Translations } from './registry'
-import { getLanguage, getLocale } from './locale'
+import type { AppTranslations, Translations } from './registry.ts'
+import { generateFilePath } from '@nextcloud/router'
+import { getLanguage, getLocale } from './locale.ts'
 import {
 	getAppTranslations,
 	hasAppTranslations,
 	registerAppTranslations,
 	unregisterAppTranslations,
-} from './registry'
-import { generateFilePath } from '@nextcloud/router'
+} from './registry.ts'
 
 import DOMPurify from 'dompurify'
 import escapeHTML from 'escape-html'
@@ -20,6 +20,12 @@ interface TranslationOptions {
 	escape?: boolean
 	/** enable/disable sanitization (by default enabled) */
 	sanitize?: boolean
+
+	/**
+	 * This is only intended for internal usage.
+	 * @private
+	 */
+	bundle?: AppTranslations
 }
 
 interface TranslationVariableReplacementObject<T> {
@@ -116,7 +122,7 @@ export function translate<T extends string>(
 		})
 	}
 
-	const bundle = getAppTranslations(app)
+	const bundle = options?.bundle ?? getAppTranslations(app)
 	let translation = bundle.translations[text] || text
 	translation = Array.isArray(translation) ? translation[0] : translation
 
@@ -150,7 +156,7 @@ export function translatePlural<T extends string, K extends string, >(
 	options?: TranslationOptions,
 ): string {
 	const identifier = '_' + textSingular + '_::_' + textPlural + '_'
-	const bundle = getAppTranslations(app)
+	const bundle = options?.bundle ?? getAppTranslations(app)
 	const value = bundle.translations[identifier]
 
 	if (typeof value !== 'undefined') {
@@ -245,10 +251,10 @@ export function unregister(appName: string) {
  *
  *
  * @param {number} number the number of elements
+ * @param {string|undefined} language the language to use (or autodetect if not set)
  * @return {number} 0 for the singular form(, 1 for the first plural form, ...)
  */
-export function getPlural(number: number) {
-	let language = getLanguage()
+export function getPlural(number: number, language = getLanguage()) {
 	if (language === 'pt-BR') {
 		// temporary set a locale for brazilian
 		language = 'xbr'

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "@types/dompurify": "^3.2.0",
         "@types/escape-html": "^1.0.4",
         "dompurify": "^3.2.4",
-        "escape-html": "^1.0.3",
-        "node-gettext": "^3.0.0"
+        "escape-html": "^1.0.3"
       },
       "devDependencies": {
         "@nextcloud/browserslist-config": "^3.0.1",
@@ -23,6 +22,7 @@
         "@nextcloud/vite-config": "^2.3.1",
         "@types/dompurify": "^3.2.0",
         "@types/escape-html": "^1.0.4",
+        "@types/gettext-parser": "^4.0.4",
         "@types/node": "^20.17.16",
         "@types/node-gettext": "^3.0.6",
         "@vitest/coverage-v8": "^3.0.4",
@@ -1743,6 +1743,17 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/gettext-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/gettext-parser/-/gettext-parser-4.0.4.tgz",
+      "integrity": "sha512-/r+YfxWZjPwt4HMAO3ay+2e3/IWJxBJxISqKFsWJW/87XllM+r5wHvioVrD45mduQ0UR7OnzMUbMe1PZfukswg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/readable-stream": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -1783,6 +1794,24 @@
       "resolved": "https://registry.npmjs.org/@types/node-gettext/-/node-gettext-3.0.6.tgz",
       "integrity": "sha512-A0W1IyyW3Ya+Wj6fDDWWwnXWNgrDNvKkq6xKj5Korc7YIo9023LP8qVTzgwQ5SUIANg2Pm2ggA7bfTcwoPPDUQ==",
       "dev": true
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.18.tgz",
+      "integrity": "sha512-21jK/1j+Wg+7jVw1xnSwy/2Q1VgVjWuFssbYGTREPUBeZ+rqVFl2udq0IkxzPC0ZhOzVceUbyIACFZKLqKEBlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/@types/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/sizzle": {
       "version": "2.3.3",
@@ -3575,10 +3604,11 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -5296,9 +5326,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz",
-      "integrity": "sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
+      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
       "dev": true,
       "funding": [
         {
@@ -5310,6 +5340,7 @@
           "url": "https://paypal.me/naturalintelligence"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "strnum": "^1.0.5"
@@ -6689,11 +6720,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6843,13 +6869,14 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -7020,14 +7047,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/node-gettext": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-3.0.0.tgz",
-      "integrity": "sha512-/VRYibXmVoN6tnSAY2JWhNRhWYJ8Cd844jrZU/DwLVoI4vBI6ceYbd8i42sYZ9uOgDH3S7vslIKOWV/ZrT2YBA==",
-      "dependencies": {
-        "lodash.get": "^4.4.2"
-      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "@types/dompurify": "^3.2.0",
     "@types/escape-html": "^1.0.4",
     "dompurify": "^3.2.4",
-    "escape-html": "^1.0.3",
-    "node-gettext": "^3.0.0"
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@nextcloud/browserslist-config": "^3.0.1",
@@ -52,6 +51,7 @@
     "@nextcloud/vite-config": "^2.3.1",
     "@types/dompurify": "^3.2.0",
     "@types/escape-html": "^1.0.4",
+    "@types/gettext-parser": "^4.0.4",
     "@types/node": "^20.17.16",
     "@types/node-gettext": "^3.0.6",
     "@vitest/coverage-v8": "^3.0.4",

--- a/tests/translation.test.ts
+++ b/tests/translation.test.ts
@@ -140,6 +140,7 @@ describe('translate', () => {
 
 	it('singular with missing variable', () => {
 		const text = 'Hello {name}'
+		// @ts-expect-error We test the fault tolerance when passing invalid options
 		const translation = translate('core', text, {})
 		expect(translation).toBe('Hallo {name}')
 	})
@@ -335,5 +336,10 @@ describe('getPlural', () => {
 		setLanguage('xxx')
 		expect(getPlural(0)).toBe<number>(0)
 		expect(getPlural(1)).toBe<number>(0)
+	})
+
+	it('supports manual language option', () => {
+		expect(getPlural(2, 'az')).toBe<number>(0)
+		expect(getPlural(2, 'am')).toBe<number>(1)
 	})
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,11 @@
 	"compilerOptions": {
 		"target": "ESNext",
 		"module": "ESNext",
-		"declaration": true,
 		"moduleResolution": "Bundler",
 		"outDir": "./dist",
+		"allowImportingTsExtensions": true,
+		"declaration": true,
+		"emitDeclarationOnly": true,
 		"strict": true,
 		"types": [
 			"vitest"


### PR DESCRIPTION
* Resolves https://github.com/nextcloud-libraries/nextcloud-l10n/issues/845

Instead of relying on a (insecure!) dependency we can reuse our already implemented logic for translations.
So we reuse the app translation logic also for the gettext based translations.

1. Allow to pass the translation bundle to our translation functions
2. Convert gettext JSON format to our Nextcloud translation format in the GettextBuilder.
3. Wrap the translation function within out gettext wrapper class

For the enduser this should not change anything (except that we do not have the debug messages `node-gettext` provided).