### PR TITLE
fix(isRTL): Correctly handle Urdu and Uzbek Afghan

### DIFF
--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -57,16 +57,12 @@ export function isRTL(language?: string): boolean {
 		'ps',  // 'پښتو', Pashto,
 		'sd',  // 'سنڌي', Sindhi
 		'ug',  // 'Uyghurche / ئۇيغۇرچە', Uyghur
-		'ur',  // 'اردو', Urdu
-		'uzs', // 'اوزبیکی', Uzbek Afghan
-		'yi',  // 'ייִדיש', Yiddish
+		'ur',    // 'اردو', Urdu
+		'ur-PK', // 'اردو', Urdu (nextcloud BCP47 variant)
+		'uz-AF', // 'اوزبیکی', Uzbek Afghan
+		'yi',    // 'ייִדיש', Yiddish
 		/* eslint-enable no-multi-spaces */
 	]
-
-	// special case for Uzbek Afghan
-	if ((language || getCanonicalLocale()).startsWith('uz-AF')) {
-		return true
-	}
 
 	return rtlLanguages.includes(languageCode)
 }

--- a/tests/locale.test.ts
+++ b/tests/locale.test.ts
@@ -91,7 +91,9 @@ describe('isRTL', () => {
 
 		// configured as current language
 		setLanguage('uz')
-		setLocale('uz_AF')
+		expect(isRTL()).toBe(false)
+
+		setLanguage('uz-AF')
 		expect(isRTL()).toBe(true)
 	})
 })


### PR DESCRIPTION
* Resolves #803 

Summary:
- Nextcloud uses the BCP47 code `ur-PK` for Urdu
- Use language and not locale for `Uzbek Afghan` as we do for all others