### PR TITLE
fix(registry): Prevent prototype polluting

### DIFF
--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -76,6 +76,10 @@ export function registerAppTranslations(
 	translations: Translations,
 	pluralFunction: PluralFunction,
 ) {
+	if (appId === '__proto__' || appId === 'constructor' || appId === 'prototype') {
+		throw new Error('Invalid appId')
+	}
+
 	window._oc_l10n_registry_translations = Object.assign(
 		window._oc_l10n_registry_translations || {},
 		{


### PR DESCRIPTION
Potential fix for [https://github.com/nextcloud-libraries/nextcloud-l10n/security/code-scanning/1](https://github.com/nextcloud-libraries/nextcloud-l10n/security/code-scanning/1)

To fix the problem, we need to ensure that the `appId` cannot be used to modify the `Object.prototype`. This can be achieved by validating the `appId` before using it as a key in the object assignment. We will reject any `appId` that matches `__proto__`, `constructor`, or `prototype`.