### PR TITLE
fix(locale): fallback to device preferences instead of 'en'

### DIFF
--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -9,7 +9,7 @@ const environmentLocale = Intl.DateTimeFormat().resolvedOptions().locale
  * Returns the user's locale
  */
 export function getLocale(): string {
-	return document.documentElement.dataset.locale || environmentLocale.replace(/-/g, '_')
+	return document.documentElement.dataset.locale || environmentLocale.replaceAll(/-/g, '_')
 }
 
 /**
@@ -17,14 +17,14 @@ export function getLocale(): string {
  * E.g. `en-US` instead of `en_US`
  */
 export function getCanonicalLocale(): string {
-	return getLocale().replace(/_/g, '-')
+	return getLocale().replaceAll(/_/g, '-')
 }
 
 /**
  * Returns the user's language
  */
 export function getLanguage(): string {
-	return document.documentElement.lang || environmentLocale
+	return document.documentElement.lang || navigator.language
 }
 
 /**

--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+const environmentLocale = Intl.DateTimeFormat().resolvedOptions().locale
+
 /**
  * Returns the user's locale
  */
 export function getLocale(): string {
-	return document.documentElement.dataset.locale || 'en'
+	return document.documentElement.dataset.locale || environmentLocale.replace(/-/g, '_')
 }
 
 /**
@@ -22,7 +24,7 @@ export function getCanonicalLocale(): string {
  * Returns the user's language
  */
 export function getLanguage(): string {
-	return document.documentElement.lang || 'en'
+	return document.documentElement.lang || environmentLocale
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "dev": "vite --mode development build --watch",
     "lint": "eslint .",
     "lint:fix": "eslint --fix lib tests",
-    "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
-    "test:watch": "vitest watch"
+    "test": "LANG=en-US vitest run",
+    "test:coverage": "LANG=en-US vitest run --coverage",
+    "test:watch": "LANG=en-US vitest watch"
   },
   "browserslist": [
     "extends @nextcloud/browserslist-config"

--- a/tests/locale.test.ts
+++ b/tests/locale.test.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
 	getCanonicalLocale,
 	getLanguage,
@@ -19,10 +19,13 @@ describe('getLanguage', () => {
 		expect(getLanguage()).toEqual('de-DE')
 	})
 
-	it('returns the environment locale if no language is set', () => {
-		const environmentLocale = Intl.DateTimeFormat().resolvedOptions().locale
+	it('returns the navigator language if no language is set', () => {
+		const spy = vi.spyOn(navigator, 'language', 'get')
+		spy.mockImplementationOnce(() => 'ar-EG')
+
 		setLanguage('')
-		expect(getLanguage()).toEqual(environmentLocale)
+		expect(getLanguage()).toEqual('ar-EG')
+		expect(spy).toHaveBeenCalledOnce()
 	})
 })
 
@@ -33,9 +36,8 @@ describe('getLocale', () => {
 	})
 
 	it('returns the environment locale with underscore if no locale is set', () => {
-		const environmentLocale = Intl.DateTimeFormat().resolvedOptions().locale
 		setLocale('')
-		expect(getLocale()).toEqual(environmentLocale.replace(/-/g, '_'))
+		expect(getLocale()).toEqual(process.env.LANG?.replaceAll('-', '_'))
 	})
 })
 
@@ -45,10 +47,16 @@ describe('getCanonicalLocale', () => {
 		expect(getCanonicalLocale()).toEqual('de-DE')
 	})
 
+	it('returns the set locale with multiple hyphen', () => {
+		setLocale('az_Cyrl_AZ')
+		expect(getCanonicalLocale()).toEqual('az-Cyrl-AZ')
+	})
+
 	it('returns the environment locale with hyphen if no locale is set', () => {
-		const environmentLocale = Intl.DateTimeFormat().resolvedOptions().locale
+		expect(process.env.LANG).not.toBe('')
+
 		setLocale('')
-		expect(getCanonicalLocale()).toEqual(environmentLocale)
+		expect(getCanonicalLocale()).toEqual(process.env.LANG)
 	})
 })
 

--- a/tests/locale.test.ts
+++ b/tests/locale.test.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-import { afterEach, beforeEach, describe, expect, it, test } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import {
 	getCanonicalLocale,
 	getLanguage,
@@ -13,54 +13,49 @@ import {
 const setLocale = (locale: string) => document.documentElement.setAttribute('data-locale', locale)
 const setLanguage = (lang: string) => document.documentElement.setAttribute('lang', lang)
 
-describe('getCanonicalLocale', () => {
-	afterEach(() => {
+describe('getLanguage', () => {
+	it('returns the set language as it is', () => {
+		setLanguage('de-DE')
+		expect(getLanguage()).toEqual('de-DE')
+	})
+
+	it('returns the environment locale if no language is set', () => {
+		const environmentLocale = Intl.DateTimeFormat().resolvedOptions().locale
+		setLanguage('')
+		expect(getLanguage()).toEqual(environmentLocale)
+	})
+})
+
+describe('getLocale', () => {
+	it('returns the set locale as it is with underscore', () => {
+		setLocale('de_DE')
+		expect(getLocale()).toEqual('de_DE')
+	})
+
+	it('returns the environment locale with underscore if no locale is set', () => {
+		const environmentLocale = Intl.DateTimeFormat().resolvedOptions().locale
 		setLocale('')
+		expect(getLocale()).toEqual(environmentLocale.replace(/-/g, '_'))
 	})
+})
 
-	it('Returns primary locales as is', () => {
-		setLocale('de')
-		expect(getCanonicalLocale()).toEqual('de')
-		setLocale('zu')
-		expect(getCanonicalLocale()).toEqual('zu')
-	})
-
-	it('Returns extended locales with hyphens', () => {
-		setLocale('az_Cyrl_AZ')
-		expect(getCanonicalLocale()).toEqual('az-Cyrl-AZ')
+describe('getCanonicalLocale', () => {
+	it('returns the set locale with hyphen', () => {
 		setLocale('de_DE')
 		expect(getCanonicalLocale()).toEqual('de-DE')
 	})
-})
 
-test('getLanguage', () => {
-	document.documentElement.removeAttribute('lang')
-	// Expect fallback
-	expect(getLanguage()).toBe('en')
-	setLanguage('')
-	expect(getLanguage()).toBe('en')
-
-	// Expect value
-	setLanguage('zu')
-	expect(getLanguage()).toBe('zu')
-})
-
-test('getLocale', () => {
-	document.documentElement.removeAttribute('data-locale')
-	// Expect fallback
-	expect(getLocale()).toBe('en')
-	setLocale('')
-	expect(getLocale()).toBe('en')
-
-	// Expect value
-	setLocale('de_DE')
-	expect(getLocale()).toBe('de_DE')
+	it('returns the environment locale with hyphen if no locale is set', () => {
+		const environmentLocale = Intl.DateTimeFormat().resolvedOptions().locale
+		setLocale('')
+		expect(getCanonicalLocale()).toEqual(environmentLocale)
+	})
 })
 
 describe('isRTL', () => {
 	beforeEach(() => document.documentElement.removeAttribute('data-locale'))
 
-	it('fallsback to English which is LTR', () => {
+	it('falls back to English which is LTR', () => {
 		// Expect fallback which is English = LTR
 		expect(isRTL()).toBe(false)
 	})


### PR DESCRIPTION
When language or locale is not available, `@nextcloud/l10n` fallbacks to `'en'`.

Instead, fallback to the environment (aka Web-Brrowser/OS) settings.

Alternative: fallback locale to language instead of system locale.