### PR TITLE
docs(readme): update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 # @nextcloud/l10n
 
 [![REUSE status](https://api.reuse.software/badge/github.com/nextcloud-libraries/nextcloud-l10n)](https://api.reuse.software/info/github.com/nextcloud-libraries/nextcloud-l10n)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/nextcloud-libraries/nextcloud-l10n/node.yml?branch=master)](https://github.com/nextcloud-libraries/nextcloud-l10n/actions/workflows/node.yml)
+[![Test status](https://img.shields.io/github/actions/workflow/status/nextcloud-libraries/nextcloud-l10n/node-test.yml?branch=main&label=tests)](https://github.com/nextcloud-libraries/nextcloud-l10n/actions/workflows/node-test.yml)
 [![npm](https://img.shields.io/npm/v/@nextcloud/l10n.svg)](https://www.npmjs.com/package/@nextcloud/l10n)
-[![Documentation](https://img.shields.io/badge/Documentation-online-brightgreen)](https://nextcloud.github.io/nextcloud-l10n/)
+[![Documentation](https://img.shields.io/badge/Documentation-online-brightgreen)](https://nextcloud-libraries.github.io/nextcloud-l10n/)
 
 Nextcloud L10n helpers for apps and libraries.
 


### PR DESCRIPTION
- The build status badge is not applicable on `main` anymore as the `node` workflow is not run when pushing `main`.
- Documentation was pointing to the incorrect pages URL.