### PR TITLE
chore: prepare v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,26 @@
 
 All notable changes to this project will be documented in this file.
 
-## UNRELEASED
+## 3.3.0 - 2025-05-29
 ### ℹ️ Notes
 - The Node version was increased to current LTS version 22.
 - The `callback` parameter of the `loadTranslations` method is deprecated.
   Instead just use the returned promise like `loadTranslations('app').then(callback)`.
+
+### 🚀 Enhancements
+* feat: add method to format relative time [#921](https://github.com/nextcloud-libraries/nextcloud-l10n/pull/921) ([susnux](https://github.com/susnux))
+
+### 🐛 Fixed bugs
+* fix: export types used in gettext exports [#905](https://github.com/nextcloud-libraries/nextcloud-l10n/pull/905) ([susnux](https://github.com/susnux))
+* fix(translations): use language instead of locale + refactor the `loadTranslations` method [#927](https://github.com/nextcloud-libraries/nextcloud-l10n/pull/927) ([susnux](https://github.com/susnux))
+* fix(locale): fallback to device preferences instead of 'en' [#864](https://github.com/nextcloud-libraries/nextcloud-l10n/pull/864) ([ShGKme](https://github.com/ShGKme))
+
+### Other changes
+* refactor: simplify `loadTranslations` [#928](https://github.com/nextcloud-libraries/nextcloud-l10n/pull/928) ([susnux](https://github.com/susnux))
+* chore(deps): drop unnecessary @types/dompurify [#903](https://github.com/nextcloud-libraries/nextcloud-l10n/pull/903) ([max-nextcloud](https://github.com/max-nextcloud))
+* docs(readme): update badges [#904](https://github.com/nextcloud-libraries/nextcloud-l10n/pull/904) ([st3iny](https://github.com/st3iny))
+* chore(deps): Bump dompurify to 3.2.6
+* Bump development dependencies
 
 ## 3.2.0 - 2025-02-13
 ### ℹ️ Notes

--- a/README.md
+++ b/README.md
@@ -142,3 +142,26 @@ gt.ngettext('%n Mississippi', '%n Mississippi', 3)
 // or if you are using the aliases mentioned above:
 n('%n Mississippi', '%n Mississippi', 3)
 ```
+
+## Development
+### 📤 Releasing a new version
+
+- Pull the latest changes from `main` or `stableX`
+- Checkout a new branch with the tag name (e.g `v4.0.1`): `git checkout -b v<version>`
+- Run `npm version patch --no-git-tag-version` (`npm version minor --no-git-tag-version` if minor).
+  This will return a new version name, make sure it matches what you expect
+- Generate the changelog content from the [release](https://github.com/nextcloud-libraries/nextcloud-l10n/releases) page.
+  Create a draft release, select the previous tag, click `generate` then paste the content to the `CHANGELOG.md` file
+  1. adjust the links to the merged pull requests and authors so that the changelog also works outside of GitHub
+     by running `npm run prerelease:format-changelog`.
+     This will apply this regex: `by @([^ ]+) in ((https://github.com/)nextcloud-libraries/nextcloud-l10n/pull/(\d+))`
+     Which this as the replacement: `[\#$4]($2) \([$1]($3$1)\)`
+  2. use the the version as tag AND title (e.g `v4.0.1`)
+  3. add the changelog content as description (https://github.com/nextcloud-libraries/nextcloud-l10n/releases)
+- Commit, push and create PR
+- Get your PR reviewed and merged
+- Create a milestone with the follow-up version at https://github.com/nextcloud-libraries/nextcloud-l10n/milestones
+- Move all open tickets and PRs to the follow-up
+- Close the milestone of the version you release
+- Publish the previously drafted release on GitHub
+  ![image](https://user-images.githubusercontent.com/14975046/124442568-2a952500-dd7d-11eb-82a2-402f9170231a.png)

--- a/build/format-changelog.mjs
+++ b/build/format-changelog.mjs
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+console.info('🔎 checking format of CHANGELOG.md')
+
+const file = join(import.meta.dirname, '..', 'CHANGELOG.md')
+const content = await readFile(file, { encoding: 'utf-8' })
+
+const formatted = content.replaceAll(
+	/by @([^ ]+) in ((https:\/\/github.com\/)nextcloud-libraries\/nextcloud-l10n\/pull\/(\d+))/g,
+	'[\\#$4]($2) \\([$1]($3$1)\\)',
+)
+
+if (formatted !== content) {
+	console.info('✏️ fixing format')
+	await writeFile(file, formatted)
+	console.info('🎉 done')
+} else {
+	console.info('✅ no formatting needed - done.')
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/l10n",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/l10n",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/router": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/l10n",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Nextcloud localization and translation helpers for apps and libraries",
   "keywords": [
     "nextcloud",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dev": "vite --mode development build --watch",
     "lint": "eslint .",
     "lint:fix": "eslint --fix lib tests",
+    "prerelease:format-changelog": "node build/format-changelog.mjs",
     "test": "LANG=en-US vitest run",
     "test:coverage": "LANG=en-US vitest run --coverage",
     "test:watch": "LANG=en-US vitest watch"


### PR DESCRIPTION
1. Add our consistent changelog formatting script.
2. Prepare new release.

### 🚀 Enhancements
* feat: add method to format relative time by @susnux in https://github.com/nextcloud-libraries/nextcloud-l10n/pull/921
### 🐛 Fixed bugs
* fix: export types used in gettext exports by @susnux in https://github.com/nextcloud-libraries/nextcloud-l10n/pull/905
* fix(translations): use language instead of locale + refactor the `loadTranslations` method by @susnux in https://github.com/nextcloud-libraries/nextcloud-l10n/pull/927
* fix(locale): fallback to device preferences instead of 'en' by @ShGKme in https://github.com/nextcloud-libraries/nextcloud-l10n/pull/864
### Other changes
* docs(readme): update badges by @st3iny in https://github.com/nextcloud-libraries/nextcloud-l10n/pull/904
* refactor: simplify `loadTranslations` by @susnux in https://github.com/nextcloud-libraries/nextcloud-l10n/pull/928
* chore(deps): drop unnecessary @types/dompurify [#903](https://github.com/nextcloud-libraries/nextcloud-l10n/pull/903) ([max-nextcloud](https://github.com/max-nextcloud))
