### PR TITLE
feat: add support for universal environment

### DIFF
--- a/lib/date.ts
+++ b/lib/date.ts
@@ -6,7 +6,7 @@
 
 import { getCanonicalLocale } from './locale.ts'
 
-declare let window: Nextcloud.v29.WindowWithGlobals
+declare let globalThis: Nextcloud.v29.WindowWithGlobals
 
 export type WeekDay = 0 | 1 | 2 | 3 | 4 | 5 | 6
 
@@ -17,8 +17,8 @@ export type WeekDay = 0 | 1 | 2 | 3 | 4 | 5 | 6
  */
 export function getFirstDay(): WeekDay {
 	// Server rendered
-	if (typeof window.firstDay !== 'undefined') {
-		return window.firstDay as WeekDay
+	if (typeof globalThis.firstDay !== 'undefined') {
+		return globalThis.firstDay as WeekDay
 	}
 
 	// Try to fallback to Intl
@@ -47,8 +47,8 @@ export function getFirstDay(): WeekDay {
  */
 export function getDayNames(): string[] {
 	// Server rendered
-	if (typeof window.dayNames !== 'undefined') {
-		return window.dayNames
+	if (typeof globalThis.dayNames !== 'undefined') {
+		return globalThis.dayNames
 	}
 
 	// Fallback to Intl
@@ -68,8 +68,8 @@ export function getDayNames(): string[] {
  * Get a list of day names (short names)
  */
 export function getDayNamesShort(): string[] {
-	if (typeof window.dayNamesShort !== 'undefined') {
-		return window.dayNamesShort
+	if (typeof globalThis.dayNamesShort !== 'undefined') {
+		return globalThis.dayNamesShort
 	}
 
 	// Fallback to Intl
@@ -91,8 +91,8 @@ export function getDayNamesShort(): string[] {
  */
 export function getDayNamesMin(): string[] {
 	// Server rendered
-	if (typeof window.dayNamesMin !== 'undefined') {
-		return window.dayNamesMin
+	if (typeof globalThis.dayNamesMin !== 'undefined') {
+		return globalThis.dayNamesMin
 	}
 
 	// Fallback to Intl
@@ -113,8 +113,8 @@ export function getDayNamesMin(): string[] {
  */
 export function getMonthNames(): string[] {
 	// Server rendered
-	if (typeof window.monthNames !== 'undefined') {
-		return window.monthNames
+	if (typeof globalThis.monthNames !== 'undefined') {
+		return globalThis.monthNames
 	}
 
 	// Fallback to Intl
@@ -140,8 +140,8 @@ export function getMonthNames(): string[] {
  */
 export function getMonthNamesShort(): string[] {
 	// Server rendered
-	if (typeof window.monthNamesShort !== 'undefined') {
-		return window.monthNamesShort
+	if (typeof globalThis.monthNamesShort !== 'undefined') {
+		return globalThis.monthNamesShort
 	}
 
 	// Fallback to Intl

--- a/lib/globals.d.ts
+++ b/lib/globals.d.ts
@@ -1,0 +1,18 @@
+/*!
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/* eslint-disable no-var, camelcase */
+
+import type { PluralFunction, Translations } from './registry.ts'
+
+declare global {
+	var _nc_l10n_locale: string
+	var _nc_l10n_language: string
+
+	var _oc_l10n_registry_translations: Record<string, Translations>
+	var _oc_l10n_registry_plural_functions: Record<string, PluralFunction>
+}
+
+export {}

--- a/lib/globals.d.ts
+++ b/lib/globals.d.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-/* eslint-disable no-var, camelcase */
+/* eslint-disable camelcase */
 
 import type { PluralFunction, Translations } from './registry.ts'
 

--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -3,13 +3,11 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-const environmentLocale = Intl.DateTimeFormat().resolvedOptions().locale
-
 /**
  * Returns the user's locale
  */
 export function getLocale(): string {
-	return document.documentElement.dataset.locale || environmentLocale.replaceAll(/-/g, '_')
+	return globalThis._nc_l10n_locale
 }
 
 /**
@@ -24,7 +22,21 @@ export function getCanonicalLocale(): string {
  * Returns the user's language
  */
 export function getLanguage(): string {
-	return document.documentElement.lang || navigator.language
+	return globalThis._nc_l10n_language
+}
+
+/**
+ * Set the current user's language (locally).
+ *
+ * @param lang - The new language code
+ */
+export function setLanguage(lang: string): void {
+	globalThis._nc_l10n_language = lang
+
+	// also for browsers set the DOM
+	if (typeof document !== 'undefined') {
+		document.documentElement.lang = lang
+	}
 }
 
 /**
@@ -68,3 +80,11 @@ export function isRTL(language?: string): boolean {
 
 	return rtlLanguages.includes(languageCode)
 }
+
+// Initialize global state if needed (e.g. when not in DOM context like on WebWorker)
+
+globalThis._nc_l10n_locale ??= (typeof document !== 'undefined' && document.documentElement.dataset.locale)
+	|| Intl.DateTimeFormat().resolvedOptions().locale.replaceAll(/-/g, '_')
+
+globalThis._nc_l10n_language ??= (typeof document !== 'undefined' && document.documentElement.lang)
+	|| (globalThis.navigator?.language ?? 'en')

--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -19,6 +19,22 @@ export function getCanonicalLocale(): string {
 }
 
 /**
+ * Set the current user's language (locally).
+ * This is to be used only for e.g. usage within web workers etc.
+ *
+ * @param locale - The new language code
+ * @since 3.4.0
+ */
+export function setLocale(locale: string): void {
+	globalThis._nc_l10n_locale = locale
+
+	// also for browsers set the DOM
+	if (typeof document !== 'undefined') {
+		document.documentElement.dataset.locale = locale
+	}
+}
+
+/**
  * Returns the user's language
  */
 export function getLanguage(): string {
@@ -27,8 +43,10 @@ export function getLanguage(): string {
 
 /**
  * Set the current user's language (locally).
+ * This is to be used only for e.g. usage within web workers etc.
  *
  * @param lang - The new language code
+ * @since 3.4.0
  */
 export function setLanguage(lang: string): void {
 	globalThis._nc_l10n_language = lang

--- a/lib/translation.ts
+++ b/lib/translation.ts
@@ -63,7 +63,7 @@ export function translate<T extends string>(app: string, text: T, placeholders?:
  * @param optionsOrNumber - The translation options or a number to replace `%n` with
  * @param options - Options object
  * @param options.escape - Enable/disable auto escape of placeholders (by default enabled)
- * @param options.sanitize - Enable/disable sanitization (by default enabled)
+ * @param options.sanitize - Enable/disable sanitization (by default enabled) [WARNING: This only work in DOM environment!]
  */
 export function translate<T extends string>(
 	app: string,
@@ -92,7 +92,7 @@ export function translate<T extends string>(
 	}
 
 	const identity = <T>(value: T): T => value
-	const optSanitize = allOptions.sanitize ? DOMPurify.sanitize : identity
+	const optSanitize = (allOptions.sanitize ? DOMPurify.sanitize : identity) || identity
 	const optEscape = allOptions.escape ? escapeHTML : identity
 
 	const isValidReplacement = (value: unknown) => typeof value === 'string' || typeof value === 'number'

--- a/package.json
+++ b/package.json
@@ -42,8 +42,10 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix lib tests",
     "prerelease:format-changelog": "node build/format-changelog.mjs",
-    "test": "LANG=en-US vitest run",
+    "test": "npm run test:dom && npm run test:node",
     "test:coverage": "LANG=en-US vitest run --coverage",
+    "test:dom": "LANG=en-US vitest run",
+    "test:node": "LANG=en-US vitest run --environment node",
     "test:watch": "LANG=en-US vitest watch"
   },
   "browserslist": [

--- a/tests/date.test.ts
+++ b/tests/date.test.ts
@@ -13,7 +13,7 @@ import * as localeModule from '../lib/locale.ts'
 vi.mock('../lib/locale.ts')
 const { getCanonicalLocale } = localeModule as Mocked<typeof localeModule>
 
-declare let window: Nextcloud.v24.WindowWithGlobals
+declare let globalThis: Nextcloud.v29.WindowWithGlobals
 
 describe('date', () => {
 	describe('getFirstDay', () => {
@@ -35,7 +35,7 @@ describe('date', () => {
 
 		beforeEach(() => {
 			// @ts-expect-error - Mocking for tests
-			delete window.firstDay
+			delete globalThis.firstDay
 		})
 
 		afterEach(() => {
@@ -44,22 +44,22 @@ describe('date', () => {
 			Object.defineProperty(Intl.Locale.prototype, 'weekInfo', originalWeekInfoDescriptor)
 		})
 
-		it('returns `window.firstDate` when defined', () => {
-			window.firstDay = 3
+		it('returns `globalThis.firstDate` when defined', () => {
+			globalThis.firstDay = 3
 			expect(getFirstDay()).toBe(3)
 		})
 
-		it('returns 1 (Monday) in "de-DE" locale when `window.firstDate` is not defined but `Intl.weekInfo` is defined (Node.js, Samsung Internet)', () => {
+		it('returns 1 (Monday) in "de-DE" locale when `globalThis.firstDate` is not defined but `Intl.weekInfo` is defined (Node.js, Samsung Internet)', () => {
 			getCanonicalLocale.mockReturnValue('de-DE')
 			expect(getFirstDay()).toBe(1)
 		})
 
-		it('returns 0 (Sunday) in "en-US" locale when `window.firstDate` is not defined but `Intl.weekInfo` is defined (Node.js, Samsung Internet)', () => {
+		it('returns 0 (Sunday) in "en-US" locale when `globalThis.firstDate` is not defined but `Intl.weekInfo` is defined (Node.js, Samsung Internet)', () => {
 			getCanonicalLocale.mockReturnValue('en-US')
 			expect(getFirstDay()).toBe(0)
 		})
 
-		it('returns 1 (Monday) in "de-DE" locale when `window.firstDate` is not defined but `Intl.getWeekInfo` is defined (Chromium, Safari)', () => {
+		it('returns 1 (Monday) in "de-DE" locale when `globalThis.firstDate` is not defined but `Intl.getWeekInfo` is defined (Chromium, Safari)', () => {
 			getCanonicalLocale.mockReturnValue('de-DE')
 			// getWeekInfo is available, weekInfo is not available (Chromium, Safari)
 			Intl.Locale.prototype.getWeekInfo = mockGetWeekInfo
@@ -67,7 +67,7 @@ describe('date', () => {
 			expect(getFirstDay()).toBe(1)
 		})
 
-		it('returns 0 (Sunday) in "en-US" locale when `window.firstDate` is not defined but `Intl.getWeekInfo` is defined (Chromium, Safari)', () => {
+		it('returns 0 (Sunday) in "en-US" locale when `globalThis.firstDate` is not defined but `Intl.getWeekInfo` is defined (Chromium, Safari)', () => {
 			getCanonicalLocale.mockReturnValue('en-US')
 			// getWeekInfo is available, weekInfo is not available (Chromium, Safari)
 			Intl.Locale.prototype.getWeekInfo = mockGetWeekInfo
@@ -75,7 +75,7 @@ describe('date', () => {
 			expect(getFirstDay()).toBe(0)
 		})
 
-		it('returns 1 (Monday) when neither `window.firstDate` nor `Intl.Locale.getWeekInfo`/`weekInfo` is defined (Firefox)', () => {
+		it('returns 1 (Monday) when neither `globalThis.firstDate` nor `Intl.Locale.getWeekInfo`/`weekInfo` is defined (Firefox)', () => {
 			delete Intl.Locale.prototype.getWeekInfo
 			delete Intl.Locale.prototype.weekInfo
 			expect(getFirstDay()).toBe(1)
@@ -85,20 +85,20 @@ describe('date', () => {
 	describe('getDayNames', () => {
 		afterEach(() => {
 			// @ts-expect-error - Mocking for tests
-			delete window.dayNames
+			delete globalThis.dayNames
 		})
 
-		it('returns `window.dayNames` when defined', () => {
-			window.dayNames = ['Day 0', 'Day 1', 'Day 2', 'Day 3', 'Day 4', 'Day 5', 'Day 6']
-			expect(getDayNames()).toEqual(window.dayNames)
+		it('returns `globalThis.dayNames` when defined', () => {
+			globalThis.dayNames = ['Day 0', 'Day 1', 'Day 2', 'Day 3', 'Day 4', 'Day 5', 'Day 6']
+			expect(getDayNames()).toEqual(globalThis.dayNames)
 		})
 
-		it('returns English day names in "en-US" locale when `window.dayNames` is not defined', () => {
+		it('returns English day names in "en-US" locale when `globalThis.dayNames` is not defined', () => {
 			getCanonicalLocale.mockReturnValue('en-US')
 			expect(getDayNames()).toEqual(['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'])
 		})
 
-		it('returns German day names in "de-DE" locale when `window.dayNames` is not defined', () => {
+		it('returns German day names in "de-DE" locale when `globalThis.dayNames` is not defined', () => {
 			getCanonicalLocale.mockReturnValue('de-DE')
 			expect(getDayNames()).toEqual(['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'])
 		})
@@ -107,20 +107,20 @@ describe('date', () => {
 	describe('getDayNamesShort', () => {
 		afterEach(() => {
 			// @ts-expect-error - Mocking for tests
-			delete window.dayNamesShort
+			delete globalThis.dayNamesShort
 		})
 
-		it('returns `window.dayNamesShort` when defined', () => {
-			window.dayNamesShort = ['D. 0', 'D. 1', 'D. 2', 'D. 3', 'D. 4', 'D. 5', 'D. 6']
-			expect(getDayNamesShort()).toEqual(window.dayNamesShort)
+		it('returns `globalThis.dayNamesShort` when defined', () => {
+			globalThis.dayNamesShort = ['D. 0', 'D. 1', 'D. 2', 'D. 3', 'D. 4', 'D. 5', 'D. 6']
+			expect(getDayNamesShort()).toEqual(globalThis.dayNamesShort)
 		})
 
-		it('returns English short day names from `Intl` in "en-US" locale when `window.dayNamesShort` is not defined', () => {
+		it('returns English short day names from `Intl` in "en-US" locale when `globalThis.dayNamesShort` is not defined', () => {
 			getCanonicalLocale.mockReturnValue('en-US')
 			expect(getDayNamesShort()).toEqual(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'])
 		})
 
-		it('returns German short day names from `Intl` in "de-DE" locale when `window.dayNamesShort` is not defined', () => {
+		it('returns German short day names from `Intl` in "de-DE" locale when `globalThis.dayNamesShort` is not defined', () => {
 			getCanonicalLocale.mockReturnValue('de-DE')
 			expect(getDayNamesShort()).toEqual(['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'])
 		})
@@ -129,20 +129,20 @@ describe('date', () => {
 	describe('getDayNamesMin', () => {
 		afterEach(() => {
 			// @ts-expect-error - Mocking for tests
-			delete window.dayNamesMin
+			delete globalThis.dayNamesMin
 		})
 
-		it('returns `window.dayNamesMin` when defined', () => {
-			window.dayNamesMin = ['D0', 'D1', 'D2', 'D3', 'D4', 'D5', 'D6']
-			expect(getDayNamesMin()).toEqual(window.dayNamesMin)
+		it('returns `globalThis.dayNamesMin` when defined', () => {
+			globalThis.dayNamesMin = ['D0', 'D1', 'D2', 'D3', 'D4', 'D5', 'D6']
+			expect(getDayNamesMin()).toEqual(globalThis.dayNamesMin)
 		})
 
-		it('returns English narrow day names from `Intl` in "en-US" locale when `window.dayNamesMin` is not defined', () => {
+		it('returns English narrow day names from `Intl` in "en-US" locale when `globalThis.dayNamesMin` is not defined', () => {
 			getCanonicalLocale.mockReturnValue('en-US')
 			expect(getDayNamesMin()).toEqual(['S', 'M', 'T', 'W', 'T', 'F', 'S'])
 		})
 
-		it('returns German narrow day names from `Intl` in "de-DE" locale when `window.dayNamesMin` is not defined', () => {
+		it('returns German narrow day names from `Intl` in "de-DE" locale when `globalThis.dayNamesMin` is not defined', () => {
 			getCanonicalLocale.mockReturnValue('de-DE')
 			expect(getDayNamesMin()).toEqual(['S', 'M', 'D', 'M', 'D', 'F', 'S'])
 		})
@@ -151,20 +151,20 @@ describe('date', () => {
 	describe('getMonthNames', () => {
 		afterEach(() => {
 			// @ts-expect-error - Mocking for tests
-			delete window.monthNames
+			delete globalThis.monthNames
 		})
 
-		it('returns `window.monthNames` when defined', () => {
-			window.monthNames = ['Month 0', 'Month 1', 'Month 2', 'Month 3', 'Month 4', 'Month 5', 'Month 6', 'Month 7', 'Month 8', 'Month 9', 'Month 10', 'Month 11']
-			expect(getMonthNames()).toEqual(window.monthNames)
+		it('returns `globalThis.monthNames` when defined', () => {
+			globalThis.monthNames = ['Month 0', 'Month 1', 'Month 2', 'Month 3', 'Month 4', 'Month 5', 'Month 6', 'Month 7', 'Month 8', 'Month 9', 'Month 10', 'Month 11']
+			expect(getMonthNames()).toEqual(globalThis.monthNames)
 		})
 
-		it('returns English month names from `Intl` in "en-US" locale when `window.monthNames` is not defined', () => {
+		it('returns English month names from `Intl` in "en-US" locale when `globalThis.monthNames` is not defined', () => {
 			getCanonicalLocale.mockReturnValue('en-US')
 			expect(getMonthNames()).toEqual(['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'])
 		})
 
-		it('returns German month names from `Intl` in "de-DE" locale when `window.monthNames` is not defined', () => {
+		it('returns German month names from `Intl` in "de-DE" locale when `globalThis.monthNames` is not defined', () => {
 			getCanonicalLocale.mockReturnValue('de-DE')
 			expect(getMonthNames()).toEqual(['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'])
 		})
@@ -173,20 +173,20 @@ describe('date', () => {
 	describe('getMonthNamesShort', () => {
 		afterEach(() => {
 			// @ts-expect-error - Mocking for tests
-			delete window.monthNamesShort
+			delete globalThis.monthNamesShort
 		})
 
-		it('returns `window.monthNamesShort` when defined', () => {
-			window.monthNamesShort = ['M. 0', 'M. 1', 'M. 2', 'M. 3', 'M. 4', 'M. 5', 'M. 6', 'M. 7', 'M. 8', 'M. 9', 'M. 10', 'M. 11']
-			expect(getMonthNamesShort()).toEqual(window.monthNamesShort)
+		it('returns `globalThis.monthNamesShort` when defined', () => {
+			globalThis.monthNamesShort = ['M. 0', 'M. 1', 'M. 2', 'M. 3', 'M. 4', 'M. 5', 'M. 6', 'M. 7', 'M. 8', 'M. 9', 'M. 10', 'M. 11']
+			expect(getMonthNamesShort()).toEqual(globalThis.monthNamesShort)
 		})
 
-		it('returns English short month names from `Intl` in "en-US" locale when `window.monthNamesShort` is not defined', () => {
+		it('returns English short month names from `Intl` in "en-US" locale when `globalThis.monthNamesShort` is not defined', () => {
 			getCanonicalLocale.mockReturnValue('en-US')
 			expect(getMonthNamesShort()).toEqual(['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'])
 		})
 
-		it('returns German short month names from `Intl` in "de-DE" locale when `window.monthNamesShort` is not defined', () => {
+		it('returns German short month names from `Intl` in "de-DE" locale when `globalThis.monthNamesShort` is not defined', () => {
 			getCanonicalLocale.mockReturnValue('de-DE')
 			expect(getMonthNamesShort()).toEqual(['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'])
 		})

--- a/tests/gettext.test.ts
+++ b/tests/gettext.test.ts
@@ -6,8 +6,7 @@
 import { po } from 'gettext-parser'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getGettextBuilder } from '../lib/gettext.ts'
-
-const setLanguage = (lang: string) => { globalThis._nc_l10n_language = lang }
+import { setLanguage } from '../lib/locale.ts'
 
 describe('gettext', () => {
 	beforeEach(() => {

--- a/tests/gettext.test.ts
+++ b/tests/gettext.test.ts
@@ -7,7 +7,7 @@ import { po } from 'gettext-parser'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getGettextBuilder } from '../lib/gettext.ts'
 
-const setLanguage = (lang: string) => document.documentElement.setAttribute('lang', lang)
+const setLanguage = (lang: string) => { globalThis._nc_l10n_language = lang }
 
 describe('gettext', () => {
 	beforeEach(() => {

--- a/tests/is-rtl.test.ts
+++ b/tests/is-rtl.test.ts
@@ -1,0 +1,50 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { isRTL } from '../lib/locale'
+
+const setLanguage = (lang: string) => { globalThis._nc_l10n_language = lang }
+
+describe('isRTL', () => {
+	beforeEach(() => { globalThis._nc_l10n_locale = 'en' })
+
+	it('falls back to English which is LTR', () => {
+		// Expect fallback which is English = LTR
+		expect(isRTL()).toBe(false)
+	})
+
+	it('uses the given argument over the current language', () => {
+		// If a value is given it should use that language over the fallback
+		expect(isRTL('ar')).toBe(true)
+		setLanguage('ar')
+		expect(isRTL('de')).toBe(false)
+	})
+
+	it('without an argument the current language is used', () => {
+		// It uses the configured language
+		setLanguage('he')
+		expect(isRTL()).toBe(true)
+	})
+
+	it('without an argument the current language is used', () => {
+		// It uses the configured language
+		setLanguage('he')
+		expect(isRTL()).toBe(true)
+	})
+
+	it('handles Uzbek Afghan correctly', () => {
+		// Given as argument
+		expect(isRTL('uz')).toBe(false)
+		expect(isRTL('uz-AF')).toBe(true)
+
+		// configured as current language
+		setLanguage('uz')
+		expect(isRTL()).toBe(false)
+
+		setLanguage('uz-AF')
+		expect(isRTL()).toBe(true)
+	})
+})

--- a/tests/is-rtl.test.ts
+++ b/tests/is-rtl.test.ts
@@ -4,12 +4,12 @@
  */
 
 import { beforeEach, describe, expect, it } from 'vitest'
-import { isRTL } from '../lib/locale'
-
-const setLanguage = (lang: string) => { globalThis._nc_l10n_language = lang }
+import { isRTL, setLanguage } from '../lib/locale.ts'
 
 describe('isRTL', () => {
-	beforeEach(() => { globalThis._nc_l10n_locale = 'en' })
+	beforeEach(() => {
+		globalThis._nc_l10n_locale = 'en'
+	})
 
 	it('falls back to English which is LTR', () => {
 		// Expect fallback which is English = LTR

--- a/tests/loadTranslations.test.ts
+++ b/tests/loadTranslations.test.ts
@@ -8,20 +8,12 @@ import type { SetupServerApi } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setLanguage } from '../lib/locale.ts'
 import { loadTranslations, register, translate, unregister } from '../lib/translation.ts'
 
 vi.mock('@nextcloud/router', () => ({
 	generateFilePath: (app: string, type: string, path: string) => `http://localhost/${app}/${type}/${path}`,
 }))
-
-/**
- * Mock the langauge
- *
- * @param lang - The language to mock
- */
-function setLanguage(lang: string): void {
-	globalThis._nc_l10n_language = lang
-}
 
 const requestHandlers = [
 	http.get('http://localhost/myapp/l10n/de.json', () => HttpResponse.json({

--- a/tests/locale.test.ts
+++ b/tests/locale.test.ts
@@ -4,100 +4,76 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-	getCanonicalLocale,
-	getLanguage,
-	getLocale,
-	isRTL,
-} from '../lib/locale.ts'
 
-const setLocale = (locale: string) => document.documentElement.setAttribute('data-locale', locale)
-const setLanguage = (lang: string) => document.documentElement.setAttribute('lang', lang)
+beforeEach(() => vi.resetModules())
 
 describe('getLanguage', () => {
-	it('returns the set language as it is', () => {
+	it('returns the set language as it is', async () => {
 		setLanguage('de-DE')
-		expect(getLanguage()).toEqual('de-DE')
+		expect(await getLanguage()).toEqual('de-DE')
 	})
 
-	it('returns the navigator language if no language is set', () => {
+	it('returns the navigator language if no language is set', async () => {
 		const spy = vi.spyOn(navigator, 'language', 'get')
 		spy.mockImplementationOnce(() => 'ar-EG')
 
-		setLanguage('')
-		expect(getLanguage()).toEqual('ar-EG')
+		setLanguage(undefined)
+		expect(await getLanguage()).toEqual('ar-EG')
 		expect(spy).toHaveBeenCalledOnce()
 	})
 })
 
 describe('getLocale', () => {
-	it('returns the set locale as it is with underscore', () => {
+	it('returns the set locale as it is with underscore', async () => {
 		setLocale('de_DE')
-		expect(getLocale()).toEqual('de_DE')
+		expect(await getLocale()).toEqual('de_DE')
 	})
 
-	it('returns the environment locale with underscore if no locale is set', () => {
-		setLocale('')
-		expect(getLocale()).toEqual(process.env.LANG?.replaceAll('-', '_'))
+	it('returns the environment locale with underscore if no locale is set', async () => {
+		setLocale(undefined)
+		expect(await getLocale()).toEqual(process.env.LANG?.replaceAll('-', '_').split('.')[0])
 	})
 })
 
 describe('getCanonicalLocale', () => {
-	it('returns the set locale with hyphen', () => {
+	it('returns the set locale with hyphen', async () => {
 		setLocale('de_DE')
-		expect(getCanonicalLocale()).toEqual('de-DE')
+		expect(await getCanonicalLocale()).toEqual('de-DE')
 	})
 
-	it('returns the set locale with multiple hyphen', () => {
+	it('returns the set locale with multiple hyphen', async () => {
 		setLocale('az_Cyrl_AZ')
-		expect(getCanonicalLocale()).toEqual('az-Cyrl-AZ')
+		expect(await getCanonicalLocale()).toEqual('az-Cyrl-AZ')
 	})
 
-	it('returns the environment locale with hyphen if no locale is set', () => {
-		expect(process.env.LANG).not.toBe('')
+	it('returns the environment locale with hyphen if no locale is set', async () => {
+		expect(process.env.LANG).toBeTruthy()
 
-		setLocale('')
-		expect(getCanonicalLocale()).toEqual(process.env.LANG)
-	})
-})
-
-describe('isRTL', () => {
-	beforeEach(() => document.documentElement.removeAttribute('data-locale'))
-
-	it('falls back to English which is LTR', () => {
-		// Expect fallback which is English = LTR
-		expect(isRTL()).toBe(false)
-	})
-
-	it('uses the given argument over the current language', () => {
-		// If a value is given it should use that language over the fallback
-		expect(isRTL('ar')).toBe(true)
-		setLanguage('ar')
-		expect(isRTL('de')).toBe(false)
-	})
-
-	it('without an argument the current language is used', () => {
-		// It uses the configured language
-		setLanguage('he')
-		expect(isRTL()).toBe(true)
-	})
-
-	it('without an argument the current language is used', () => {
-		// It uses the configured language
-		setLanguage('he')
-		expect(isRTL()).toBe(true)
-	})
-
-	it('handles Uzbek Afghan correctly', () => {
-		// Given as argument
-		expect(isRTL('uz')).toBe(false)
-		expect(isRTL('uz-AF')).toBe(true)
-
-		// configured as current language
-		setLanguage('uz')
-		expect(isRTL()).toBe(false)
-
-		setLanguage('uz-AF')
-		expect(isRTL()).toBe(true)
+		setLocale(undefined)
+		expect(await getCanonicalLocale()).toEqual(process.env.LANG!.split('.')[0])
 	})
 })
+
+async function getCanonicalLocale() {
+	const { getCanonicalLocale } = await import('../lib/locale.ts')
+	return getCanonicalLocale()
+}
+
+async function getLocale() {
+	const { getLocale } = await import('../lib/locale.ts')
+	return getLocale()
+}
+
+async function getLanguage() {
+	const { getLanguage } = await import('../lib/locale.ts')
+	return getLanguage()
+}
+
+function setLanguage(lang?: string) {
+	// @ts-expect-error - Mocking global state
+	globalThis._nc_l10n_language = lang
+}
+function setLocale(locale?: string) {
+	// @ts-expect-error - Mocking global state
+	globalThis._nc_l10n_locale = locale
+}

--- a/tests/time.test.ts
+++ b/tests/time.test.ts
@@ -4,9 +4,8 @@
  */
 
 import { beforeAll, beforeEach, describe, expect, it, test, vi } from 'vitest'
+import { setLanguage } from '../lib/locale.ts'
 import { formatRelativeTime } from '../lib/time.ts'
-
-const setLanguage = (lang: string) => { globalThis._nc_l10n_language = lang }
 
 describe('time - formatRelativeTime', () => {
 	beforeAll(() => {

--- a/tests/time.test.ts
+++ b/tests/time.test.ts
@@ -6,7 +6,7 @@
 import { beforeAll, beforeEach, describe, expect, it, test, vi } from 'vitest'
 import { formatRelativeTime } from '../lib/time.ts'
 
-const setLanguage = (lang: string) => document.documentElement.setAttribute('lang', lang)
+const setLanguage = (lang: string) => { globalThis._nc_l10n_language = lang }
 
 describe('time - formatRelativeTime', () => {
 	beforeAll(() => {

--- a/tests/translation.test.ts
+++ b/tests/translation.test.ts
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import type { NextcloudWindowWithRegistry } from '../lib/registry.ts'
-
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { setLanguage, setLocale } from '../lib/locale.ts'
 import {
 	getPlural,
 	n,
@@ -15,9 +14,6 @@ import {
 	translatePlural,
 	unregister,
 } from '../lib/translation.ts'
-
-const setLocale = (locale: string) => { globalThis._nc_l10n_locale = locale }
-const setLanguage = (lang: string) => { globalThis._nc_l10n_language = lang }
 
 describe('translate', () => {
 	const mockWindowDE = () => {

--- a/tests/translation.test.ts
+++ b/tests/translation.test.ts
@@ -16,14 +16,12 @@ import {
 	unregister,
 } from '../lib/translation.ts'
 
-declare const window: NextcloudWindowWithRegistry
-
-const setLocale = (locale: string) => document.documentElement.setAttribute('data-locale', locale)
-const setLanguage = (lang: string) => document.documentElement.setAttribute('lang', lang)
+const setLocale = (locale: string) => { globalThis._nc_l10n_locale = locale }
+const setLanguage = (lang: string) => { globalThis._nc_l10n_language = lang }
 
 describe('translate', () => {
 	const mockWindowDE = () => {
-		window._oc_l10n_registry_translations = {
+		globalThis._oc_l10n_registry_translations = {
 			core: {
 				'Hello world!': 'Hallo Welt!',
 				'Hello {name}': 'Hallo {name}',
@@ -37,7 +35,7 @@ describe('translate', () => {
 				],
 			},
 		}
-		window._oc_l10n_registry_plural_functions = {
+		globalThis._oc_l10n_registry_plural_functions = {
 			core: (t) => t === 1 ? 0 : 1,
 		}
 		setLocale('de')
@@ -110,19 +108,20 @@ describe('translate', () => {
 		expect(translation).toBe('Hallo <img src=x onerror=alert(1)//>')
 	})
 
-	it('with placeholder XSS sanitizing', () => {
-		const text = 'Hello {name}'
-		const translation = translate('core', text, { name: '<img src=x onerror=alert(1)//>' }, undefined, { escape: false })
-		expect(translation).toBe('Hallo <img src="x">')
-	})
-
 	it('with number as third parameter', () => {
 		const text = 'Number: %n'
 		const translation = translate('core', text, 4)
 		expect(translation).toBe('Number: 4')
 	})
 
-	it('with options as forth parameter', () => {
+	// DOMPurify only works with real DOM
+	it.skipIf(typeof globalThis.document === 'undefined')('with placeholder XSS sanitizing', () => {
+		const text = 'Hello {name}'
+		const translation = translate('core', text, { name: '<img src=x onerror=alert(1)//>' }, undefined, { escape: false })
+		expect(translation).toBe('Hallo <img src="x">')
+	})
+
+	it.skipIf(typeof globalThis.document === 'undefined')('with options as forth parameter', () => {
 		const text = 'Hello {name}'
 		const translation = translate('core', text, { name: '<img src=x onerror=alert(1)//>' }, { escape: false })
 		expect(translation).toBe('Hallo <img src="x">')
@@ -215,8 +214,8 @@ describe('translate', () => {
 describe('register', () => {
 	beforeEach(() => {
 		setLocale('de_DE')
-		window._oc_l10n_registry_translations = undefined
-		window._oc_l10n_registry_plural_functions = undefined
+		globalThis._oc_l10n_registry_translations = {}
+		globalThis._oc_l10n_registry_plural_functions = {}
 	})
 
 	it('with blank registry', () => {
@@ -230,12 +229,12 @@ describe('register', () => {
 	})
 
 	it('extend registered translations', () => {
-		window._oc_l10n_registry_translations = {
+		globalThis._oc_l10n_registry_translations = {
 			app: {
 				Application: 'Anwendung',
 			},
 		}
-		window._oc_l10n_registry_plural_functions = {
+		globalThis._oc_l10n_registry_plural_functions = {
 			app: (t) => t === 1 ? 0 : 1,
 		}
 		register('app', {
@@ -246,12 +245,12 @@ describe('register', () => {
 	})
 
 	it('extend with another new app', () => {
-		window._oc_l10n_registry_translations = {
+		globalThis._oc_l10n_registry_translations = {
 			core: {
 				'Hello world!': 'Hallo Welt!',
 			},
 		}
-		window._oc_l10n_registry_plural_functions = {
+		globalThis._oc_l10n_registry_plural_functions = {
 			core: (t) => t === 1 ? 0 : 1,
 		}
 		register('app', {
@@ -262,8 +261,8 @@ describe('register', () => {
 	})
 
 	it('unregister', () => {
-		window._oc_l10n_registry_translations = {}
-		window._oc_l10n_registry_plural_functions = {}
+		globalThis._oc_l10n_registry_translations = {}
+		globalThis._oc_l10n_registry_plural_functions = {}
 		register('app', {
 			Application: 'Anwendung',
 		})
@@ -273,6 +272,11 @@ describe('register', () => {
 })
 
 describe('getPlural', () => {
+	beforeEach(() => {
+		globalThis._oc_l10n_registry_translations = {}
+		globalThis._oc_l10n_registry_plural_functions = {}
+	})
+
 	it('handles single form language like Azerbaijani', () => {
 		setLanguage('az')
 		expect(getPlural(0)).toBe(0)

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,9 +1,5 @@
 {
 	"extends": "../tsconfig.json",
-	"compilerOptions": {
-		// Allow us to pass js files to ts-jest without babel
-		"allowJs": true,
-	},
-	"include": ["./**.ts"],
+	"include": ["./**.ts", "../lib/**.ts"],
 	"exclude": []
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,11 @@ export default createLibConfig(
 		config: defineConfig({
 			test: {
 				environment: 'jsdom',
+				environmentOptions: {
+					jsdom: {
+						url: 'http://localhost',
+					},
+				},
 				coverage: {
 					reporter: ['text', 'lcov'],
 				},


### PR DESCRIPTION
- Resolves #830
- Based on #832

Allows to use the library in web workers and similar other places.
- Adjusted `window` and `document` usage (`globalThis`)
- Add global state handling as there is no document
- Added tests for also non-DOM environment

Limitations in non DOM environments:
- Sanitizing of HTML does not work as DOMPurify needs a DOM
- `loadTranslations` needs `@nextcloud/router` to work