### PR TITLE
feat(gettext): allow to add translations to the wrapper

### DIFF
--- a/tests/gettext.test.ts
+++ b/tests/gettext.test.ts
@@ -214,4 +214,26 @@ msgstr "incorrect"
 
 		expect(translation).toEqual('correct')
 	})
+
+	it('can add translations afterwards', () => {
+		const pot = `msgid ""
+msgstr ""
+"Last-Translator: Translator, 2020\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: sv\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "abc"
+msgstr "def"
+`
+		const gt = getGettextBuilder()
+			.setLanguage('sv')
+			.build()
+
+		expect(gt.gettext('abc')).toBe('abc')
+
+		gt.addTranslations(po.parse(pot))
+
+		expect(gt.gettext('abc')).toBe('def')
+	})
 })


### PR DESCRIPTION
This allows us to only register what is needed.
Normally you would register everything at once,
but for performance reasons the `nextcloud-vue`
library only registers the translations of components that are really used.